### PR TITLE
Add settings link to plugin actions.

### DIFF
--- a/src/Settings/SettingsTab.php
+++ b/src/Settings/SettingsTab.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\OrderSourceAttribution\Settings;
 
+use Automattic\WooCommerce\OrderSourceAttribution\HelperTraits\Utilities;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -9,6 +11,9 @@ defined( 'ABSPATH' ) || exit;
  * @since x.x.x
  */
 class SettingsTab {
+
+	use Utilities;
+
 	const SETTINGS_ENABLE_ORDER_ATTRIBUTION_ID = 'wc_order_source_attribution_enable_order_source_data';
 	const SETTINGS_DEBUG_MODE_ID               = 'wc_order_source_attribution_debug_mode';
 
@@ -38,6 +43,26 @@ class SettingsTab {
 			},
 			90
 		);
+
+		add_filter(
+			'plugin_action_links_' . $this->get_plugin_base_name(),
+			function ( $links ) {
+				$settings_url = add_query_arg(
+					[
+						'page' => 'wc-settings',
+						'tab'  => 'wc_order_source_attribution',
+					],
+					admin_url( 'admin.php' )
+				);
+				$action_links = [
+					'settings' => '<a href="' . $settings_url . '">' . esc_html__( 'Settings', 'woocommerce-order-source-attribution' ) . '</a>',
+				];
+
+				return array_merge( $action_links, $links );
+
+			}
+		);
+
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We recently added a settings page to the plugin. This PR sets up a link to the settings.

_Replace this with a good description of your changes & reasoning._

### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?

### Screenshots:

Before:
![Screenshot 2023-02-23 at 11 28 28](https://user-images.githubusercontent.com/4209011/220868525-bc30de58-6980-40de-a09d-e2688e330c08.jpg)

After:
![Screenshot 2023-02-23 at 11 29 01](https://user-images.githubusercontent.com/4209011/220868518-f2924653-dd94-4413-8b17-c32a77a5aa10.jpg)

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this branch
2. Navigate to admin -> plugins and confirm that Grow Order Attribute Prototype has a settings link.
3. Confirm the Settings link takes you to our settings page.


### Changelog entry

> Add - Set up settings link to plugin actions.
