### PR TITLE
Remove wp 5.8 from test matrix.

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         php: [7.4]
-        wp-version: [5.8, 5.9, latest]
+        wp-version: ["5.9", "6.0", latest]
         include:
           - php: 8.0
             wp-version: latest


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove wp 5.8 from  test matrix.

relates to #34
