### PR TITLE
Fix  duplicates data in origin column

### DIFF
--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -402,8 +402,6 @@ class AttributionFields {
 			$theorder = wc_get_order( $post->ID );
 		}
 
-		OrderUtil::init_theorder_object( $post );
-
 		// Throw an exception if we don't have an order object.
 		if ( ! $theorder instanceof WC_Order ) {
 			throw new Exception( __( 'Order not found.', 'woocommerce-order-source-attribution' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

See #39.

Ensure the global $theorder is updated to avoid the same origin data being returned for all order rows.

Closes #39.


### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?

### Screenshots:

Current branch:
![Screenshot 2023-02-28 at 13 44 56](https://user-images.githubusercontent.com/4209011/221844998-89593b08-0a25-4bb8-ab96-05ca7700cef9.jpg)

Main:
![Screenshot 2023-02-28 at 13 44 40](https://user-images.githubusercontent.com/4209011/221845015-4fc038dc-2d9e-4387-965c-9c6cdacd7e04.jpg)


### Detailed test instructions:

1. Using a URL with some tracking data, order a product. E.g, https://woocommerce.test/products/woocommerce-google-analytics?utm_source=social&utm_medium=banner&utm_campaign=FB&utm_id=FB
2. Navigate to the admin -> woocommerce -> orders page.
3. Confirm the origin data reflect the value saved.


### Changelog entry

> Fix - Duplicates data displayed for all orders in origin column
