### PR TITLE
exclude phpunit.xml from build bundle.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@ composer.json export-ignore
 composer.lock export-ignore
 phpcs.xml.dist export-ignore
 phpunit.xml.dist export-ignore
+phpunit.xml export-ignore
 webpack.config.js export-ignore
 webpack-development.config.js export-ignore
 jest.config.js export-ignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the WCCOM PR https://github.com/Automattic/woocommerce.com/pull/16156, @JPry noted that we included the phpunit.xml file, which should not be included. This PR ensures that future build zip files do not include the phpunit.xml file.


### Checks:
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?


### Detailed test instructions:

1. Check out this branch and run `npm run build`. 
2. Ensure that the generated zip file does not include phpunit.xml.


### Changelog entry

> Tweak - exclude phpunit.xml from the build bundle.
