### PR TITLE
Remove redundant "if" checks.

### DIFF
--- a/assets/js/wccom-integration.js
+++ b/assets/js/wccom-integration.js
@@ -1,9 +1,5 @@
 window.addEventListener( 'load' , function ( e ) {
 	if ( window.wccom && window.wccom.canTrackUser('analytics') ) {
-
-		if ( ! wccom || ! wccom.canTrackUser( 'analytics' ) ) {
-			return;
-		}
 		window.woocommerce_order_source_attribution.setAllowTrackingConsent( true );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

A review on WCCOM PR (https://github.com/Automattic/woocommerce.com/pull/16156) has pointed out that we're performing the same `if` check: `! wccom || ! wccom.canTrackUser( 'analytics' ) ` twice. This PR removed the extra `if` check.


### Changelog entry

> Tweak - Remove redundant "if" checks.
