### PR TITLE
Add/handle sources

### DIFF
--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -382,12 +382,15 @@ class AttributionFields {
 
 		switch ( $source_type ) {
 			case 'utm':
+				/* translators: %s is the source value */
 				$label = esc_html__( 'Source: %s', 'woocommerce-order-source-attribution' );
 				break;
 			case 'organic':
+				/* translators: %s is the source value */
 				$label = esc_html__( 'Organic: %s', 'woocommerce-order-source-attribution' );
 				break;
 			case 'referral':
+				/* translators: %s is the source value */
 				$label = esc_html__( 'Referral: %s', 'woocommerce-order-source-attribution' );
 				break;
 		}

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -378,7 +378,25 @@ class AttributionFields {
 		$source_type      = $order->get_meta( '_wc_order_source_attribution_source_type' );
 		$source           = $order->get_meta( '_wc_order_source_attribution_utm_source' ) ?: esc_html__( '(none)', 'woocommerce-order-source-attribution' );
 		$formatted_source = ucfirst( trim( $source, '()' ) );
-		$label            = '';
+		$label            = $this->get_source_label( $source_type );
+
+		if ( empty( $label ) ) {
+			echo esc_html( $formatted_source );
+			return;
+		}
+
+		printf( $label, esc_html( $formatted_source ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+
+	/**
+	 * Returns the label based on the source type.
+	 *
+	 * @param string $source_type The source type.
+	 * @return string The label for the source type.
+	 */
+	private function get_source_label( string $source_type ) {
+		$label = '';
 
 		switch ( $source_type ) {
 			case 'utm':
@@ -395,13 +413,7 @@ class AttributionFields {
 				break;
 		}
 
-		if ( empty( $label ) ) {
-			echo esc_html( $formatted_source );
-			return;
-		}
-
-		printf( $label, esc_html( $formatted_source ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-
+		return $label;
 	}
 
 	/**

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -396,7 +396,7 @@ class AttributionFields {
 		}
 
 		if ( empty( $label ) ) {
-			echo  esc_html( $formatted_source );
+			echo esc_html( $formatted_source );
 			return;
 		}
 

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -374,14 +374,31 @@ class AttributionFields {
 	 *
 	 * @return void
 	 */
-	private function output_origin_column( WC_Order $order ) {
-		$source = $order->get_meta( '_wc_order_source_attribution_source_type' ) ?: esc_html__( '(none)', 'woocommerce-order-source-attribution' );
+	public function output_origin_column( WC_Order $order ) {
+		$source_type      = $order->get_meta( '_wc_order_source_attribution_source_type' );
+		$source           = $order->get_meta( '_wc_order_source_attribution_utm_source' ) ?: esc_html__( '(none)', 'woocommerce-order-source-attribution' );
+		$formatted_source = ucfirst( trim( $source, '()' ) );
+		$label            = '';
 
-		printf(
-			/* translators: %s is the source type */
-			esc_html__( 'Source: %s', 'woocommerce-order-source-attribution' ),
-			esc_html( $source )
-		);
+		switch ( $source_type ) {
+			case 'utm':
+				$label = esc_html__( 'Source: %s', 'woocommerce-order-source-attribution' );
+				break;
+			case 'organic':
+				$label = esc_html__( 'Organic: %s', 'woocommerce-order-source-attribution' );
+				break;
+			case 'referral':
+				$label = esc_html__( 'Referral: %s', 'woocommerce-order-source-attribution' );
+				break;
+		}
+
+		if ( empty( $label ) ) {
+			echo  esc_html( $formatted_source );
+			return;
+		}
+
+		printf( $label, esc_html( $formatted_source ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
 	}
 
 	/**

--- a/tests/Unit/AttributionFieldsTest.php
+++ b/tests/Unit/AttributionFieldsTest.php
@@ -44,4 +44,61 @@ class AttributionFieldsTest extends WP_UnitTestCase {
 			->getMock();
 
 	}
+
+	/**
+	 * Tests the output_origin_column method.
+	 *
+	 * @return void
+	 */
+	public function test_output_origin_column() {
+
+		$attribution_field_class = new AttributionFields( self::$dummy_logger );
+
+		// Define the expected output for each test case.
+		$test_cases = array(
+			array(
+				'source_type'     => 'utm',
+				'source'          => 'example',
+				'expected_output' => 'Source: Example',
+			),
+			array(
+				'source_type'     => 'organic',
+				'source'          => 'example',
+				'expected_output' => 'Organic: Example',
+			),
+			array(
+				'source_type'     => 'referral',
+				'source'          => 'example',
+				'expected_output' => 'Referral: Example',
+			),
+			array(
+				'source_type'     => 'typein',
+				'source'          => '(direct)',
+				'expected_output' => 'Direct',
+			),
+			array(
+				'source_type'     => '',
+				'source'          => '',
+				'expected_output' => 'None',
+			),
+		);
+
+		foreach ( $test_cases as $test_case ) {
+			// Create a mock WC_Order object.
+			$order = $this->getMockBuilder( \WC_Order::class )
+				->onlyMethods( array( 'get_meta' ) )
+				->getMock();
+			$order->method( 'get_meta' )
+				->willReturnOnConsecutiveCalls( $test_case['source_type'], $test_case['source'] );
+
+			// Capture the output.
+			ob_start();
+
+			$attribution_field_class->output_origin_column( $order );
+
+			$output = ob_get_clean();
+
+			$this->assertEquals( $test_case['expected_output'], $output );
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I followed the design recommendation to output different sources (e.g. social) display in Order table.

Made output_origin_column public to add unit test.

Closes #28.


### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?

### Screenshots:

![Screenshot 2023-04-19 at 15 49 09](https://user-images.githubusercontent.com/4209011/233120604-4edff2ae-d116-4139-bdde-b52d15bb9f07.jpg)


### Detailed test instructions:


1. Create an order. The different sources can be simulated by setting the values of the wc_order_source_attribution field on the order checkout.
2. Confirm that different cases are properly handled


### Additional details:

I don't parse the source values beyond rendering out the different labels as per the source type.

### Changelog entry

> Add - Handle different sources display in order table
