### PR TITLE
Move the enable/disable setting under Advanced > Features > Experimental

### DIFF
--- a/src/HelperTraits/Utilities.php
+++ b/src/HelperTraits/Utilities.php
@@ -30,8 +30,8 @@ trait Utilities {
 	 * @return bool
 	 */
 	protected function is_debug_mode_enabled() {
-		return 'yes' === get_option( SettingsTab::SETTINGS_DEBUG_MODE_ID, 'no' );
+		$option = 'yes' === get_option( SettingsTab::SETTINGS_DEBUG_MODE_ID, 'no' );
+
+		return (bool) apply_filters( 'wc_order_source_attribution_debug_mode_enabled', $option );
 	}
-
 }
-

--- a/src/Settings/SettingsTab.php
+++ b/src/Settings/SettingsTab.php
@@ -83,10 +83,10 @@ class SettingsTab {
 		// Add our own settings to the end of the featured section.
 		$order_attribution_settings = [
 			[
-				'title'   => __( 'Order Attribution', 'woocommerce-order-source-attribution' ),
+				'title'   => __( 'Order Attribution (Beta)', 'woocommerce-order-source-attribution' ),
 				'type'    => 'checkbox',
 				'default' => 'yes',
-				'desc'    => __( 'Enable WooCommerce Order Source Attribution.', 'woocommerce-order-source-attribution' ),
+				'desc'    => __( 'Enable this feature to track and credit channels and campaigns that contribute to orders on your site.', 'woocommerce-order-source-attribution' ),
 				'id'      => self::SETTINGS_ENABLE_ORDER_ATTRIBUTION_ID,
 			],
 		];

--- a/src/Settings/SettingsTab.php
+++ b/src/Settings/SettingsTab.php
@@ -54,13 +54,18 @@ class SettingsTab {
 	}
 
 	/**
-	 * Add our setting to the Experimental Features section.
+	 * Add our setting to the end of the Experimental Features section.
 	 *
 	 * @param array $settings
 	 *
 	 * @return array
 	 */
 	private function add_experimental_settings( array $settings ) {
+		/*
+		 * The array of settings has numerically-indexed items as the settings, and key-indexed
+		 * items that were used to generate the settings. This strips out the key-indexed
+		 * items for our logic.
+		 */
 		$numeric_only_settings = array_filter(
 			$settings,
 			function( $key ) {
@@ -69,13 +74,13 @@ class SettingsTab {
 			ARRAY_FILTER_USE_KEY
 		);
 
-		// Add our own settings in the featured section.
-		$ids = array_column( $numeric_only_settings, 'id' );
-		$feature_begin_index = array_search( 'experimental_features_options', $ids, true );
-		if ( false === $feature_begin_index ) {
+		// Look for the beginning and end of the experimental_features_options section.
+		$indices = array_keys( array_column( $numeric_only_settings, 'id' ), 'experimental_features_options', true );
+		if ( 2 !== count( $indices ) ) {
 			return $settings;
 		}
 
+		// Add our own settings to the end of the featured section.
 		$order_attribution_settings = [
 			[
 				'title'   => __( 'Order Attribution', 'woocommerce-order-source-attribution' ),
@@ -86,13 +91,10 @@ class SettingsTab {
 			],
 		];
 
-		$first_section = array_slice( $numeric_only_settings, 0, $feature_begin_index + 1 );
-		$second_section = array_slice( $numeric_only_settings, $feature_begin_index + 1 );
-
 		return array_merge(
-			$first_section,
+			array_slice( $numeric_only_settings, 0, $indices[1] ),
 			$order_attribution_settings,
-			$second_section
+			array_slice( $numeric_only_settings, $indices[1] )
 		);
 	}
 }

--- a/src/Settings/SettingsTab.php
+++ b/src/Settings/SettingsTab.php
@@ -22,30 +22,7 @@ class SettingsTab {
 	 */
 	public function register() {
 		add_filter(
-			'woocommerce_settings_tabs_array',
-			function( $settings_tabs ) {
-				return $this->add_settings_tab( $settings_tabs );
-			},
-			50
-		);
-
-		add_action(
-			'woocommerce_settings_wc_order_source_attribution',
-			function() {
-				$this->settings_tab();
-			}
-		);
-
-		add_action(
-			'woocommerce_update_options_wc_order_source_attribution',
-			function() {
-				$this->update_settings();
-			},
-			90
-		);
-
-		add_filter(
-			'plugin_action_links_' . $this->get_plugin_base_name(),
+			"plugin_action_links_{$this->get_plugin_base_name()}",
 			function ( $links ) {
 				$settings_url = add_query_arg(
 					[
@@ -59,76 +36,70 @@ class SettingsTab {
 				];
 
 				return array_merge( $action_links, $links );
-
 			}
 		);
 
+		add_filter(
+			'woocommerce_get_settings_advanced',
+			function( $settings, $current_section ) {
+				if ( 'features' !== $current_section ) {
+					return $settings;
+				}
+
+				return $this->add_experimental_settings( $settings );
+			},
+			100,
+			2
+		);
 	}
 
-
 	/**
-	 * Add a new settings tab to the WooCommerce settings tabs array.
+	 * Add our setting to the Experimental Features section.
 	 *
-	 * @param array $settings_tabs Array of WooCommerce setting tabs.
-	 * @return array $settings_tabs Array of WooCommerce setting tabs.
-	 */
-	private function add_settings_tab( $settings_tabs ) {
-		$settings_tabs['wc_order_source_attribution'] = __( 'Order Attribution', 'woocommerce-order-source-attribution' );
-		return $settings_tabs;
-	}
-
-
-	/**
-	 * Uses the WooCommerce admin fields API to output settings via the @see woocommerce_admin_fields() function.
-	 */
-	private function settings_tab() {
-		woocommerce_admin_fields( $this->get_settings() );
-	}
-
-
-	/**
-	 * Uses the WooCommerce options API to save settings via the @see woocommerce_update_options() function.
-	 */
-	private function update_settings() {
-		woocommerce_update_options( $this->get_settings() );
-	}
-
-
-	/**
-	 * Get all the settings for this plugin for @see woocommerce_admin_fields() function.
+	 * @param array $settings
 	 *
-	 * @return array Array of settings for @see woocommerce_admin_fields() function.
+	 * @return array
 	 */
-	private function get_settings() {
-		$is_enabled = get_option( self::SETTINGS_ENABLE_ORDER_ATTRIBUTION_ID, 'yes' );
-		$debug_mode = get_option( self::SETTINGS_DEBUG_MODE_ID, 'no' );
+	private function add_experimental_settings( array $settings ) {
+		$numeric_only_settings = array_filter(
+			$settings,
+			function( $key ) {
+				return is_int( $key );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
 
-		return array(
-			'section_title' => array(
-				'name' => __( 'WooCommerce Order Source Attribution Settings', 'woocommerce-order-source-attribution' ),
-				'type' => 'title',
-				'desc' => '',
-				'id'   => 'wc_order_source_attribution_section_title',
-			),
-			'enabled'       => array(
+		// Add our own settings in the featured section.
+		$ids = array_column( $numeric_only_settings, 'id' );
+		$feature_begin_index = array_search( 'experimental_features_options', $ids, true );
+		if ( false === $feature_begin_index ) {
+			return $settings;
+		}
+
+		$order_attribution_settings = [
+			[
 				'title'   => __( 'Order Attribution', 'woocommerce-order-source-attribution' ),
 				'type'    => 'checkbox',
 				'default' => 'yes',
 				'desc'    => __( 'Enable WooCommerce Order Source Attribution.', 'woocommerce-order-source-attribution' ),
 				'id'      => self::SETTINGS_ENABLE_ORDER_ATTRIBUTION_ID,
-				'value'   => $is_enabled,
-			),
-			'debug_mode'    => array(
-				'title' => __( 'Debug Mode', 'woocommerce-order-source-attribution' ),
-				'type'  => 'checkbox',
-				'desc'  => __( 'Log plugin events.', 'woocommerce-order-source-attribution' ),
-				'id'    => self::SETTINGS_DEBUG_MODE_ID,
-				'value' => $debug_mode,
-			),
-			'section_end'   => array(
-				'type' => 'sectionend',
-				'id'   => 'wc_order_source_attribution_section_end',
-			),
+			],
+			'debug_mode' => [
+				'title'   => __( 'Order Attribution Debug Mode', 'woocommerce-order-source-attribution' ),
+				'type'    => 'checkbox',
+				'default' => 'no',
+				'desc'    => __( 'Log plugin events.', 'woocommerce-order-source-attribution' ),
+				'id'      => self::SETTINGS_DEBUG_MODE_ID,
+			],
+		];
+
+		$first_section = array_slice( $numeric_only_settings, 0, $feature_begin_index + 1 );
+		$second_section = array_slice( $numeric_only_settings, $feature_begin_index + 1 );
+
+		return array_merge(
+			$first_section,
+			$order_attribution_settings,
+			$second_section
 		);
 	}
 }

--- a/src/Settings/SettingsTab.php
+++ b/src/Settings/SettingsTab.php
@@ -24,18 +24,7 @@ class SettingsTab {
 		add_filter(
 			"plugin_action_links_{$this->get_plugin_base_name()}",
 			function ( $links ) {
-				$settings_url = add_query_arg(
-					[
-						'page' => 'wc-settings',
-						'tab'  => 'wc_order_source_attribution',
-					],
-					admin_url( 'admin.php' )
-				);
-				$action_links = [
-					'settings' => '<a href="' . $settings_url . '">' . esc_html__( 'Settings', 'woocommerce-order-source-attribution' ) . '</a>',
-				];
-
-				return array_merge( $action_links, $links );
+				return $this->add_plugin_links( $links );
 			}
 		);
 
@@ -51,6 +40,33 @@ class SettingsTab {
 			100,
 			2
 		);
+	}
+
+	/**
+	 * Filter the plugin action links.
+	 *
+	 * @param array $links Array of links.
+	 *
+	 * @return array
+	 */
+	private function add_plugin_links( array $links ) {
+		$settings_url = add_query_arg(
+			[
+				'page'    => 'wc-settings',
+				'tab'     => 'advanced',
+				'section' => 'features',
+			],
+			admin_url( 'admin.php' )
+		);
+		$action_links = [
+			'settings' => sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $settings_url ),
+				esc_html__( 'Settings', 'woocommerce-order-source-attribution' )
+			),
+		];
+
+		return array_merge( $action_links, $links );
 	}
 
 	/**

--- a/src/Settings/SettingsTab.php
+++ b/src/Settings/SettingsTab.php
@@ -84,13 +84,6 @@ class SettingsTab {
 				'desc'    => __( 'Enable WooCommerce Order Source Attribution.', 'woocommerce-order-source-attribution' ),
 				'id'      => self::SETTINGS_ENABLE_ORDER_ATTRIBUTION_ID,
 			],
-			'debug_mode' => [
-				'title'   => __( 'Order Attribution Debug Mode', 'woocommerce-order-source-attribution' ),
-				'type'    => 'checkbox',
-				'default' => 'no',
-				'desc'    => __( 'Log plugin events.', 'woocommerce-order-source-attribution' ),
-				'id'      => self::SETTINGS_DEBUG_MODE_ID,
-			],
 		];
 
 		$first_section = array_slice( $numeric_only_settings, 0, $feature_begin_index + 1 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #58 .

This moves the setting to enable/disable the feature to WooCommerce > Settings > Advanced > Features > Experimental

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
1. Check out this branch
2. Go to WooCommerce > Settings > Advanced > Features. See the checkbox under the "Experimental" section
3. Confirm the setting can be changed and saved.


### Changelog entry

>
