### PR TITLE
Move settings to the normal Features section

### DIFF
--- a/src/Settings/SettingsTab.php
+++ b/src/Settings/SettingsTab.php
@@ -29,16 +29,10 @@ class SettingsTab {
 		);
 
 		add_filter(
-			'woocommerce_get_settings_advanced',
-			function( $settings, $current_section ) {
-				if ( 'features' !== $current_section ) {
-					return $settings;
-				}
-
-				return $this->add_experimental_settings( $settings );
-			},
-			100,
-			2
+			'woocommerce_settings_features',
+			function( $features ) {
+				return $this->add_settings( $features );
+			}
 		);
 	}
 
@@ -70,33 +64,13 @@ class SettingsTab {
 	}
 
 	/**
-	 * Add our setting to the end of the Experimental Features section.
+	 * Add our setting to the Features section.
 	 *
 	 * @param array $settings
 	 *
 	 * @return array
 	 */
-	private function add_experimental_settings( array $settings ) {
-		/*
-		 * The array of settings has numerically-indexed items as the settings, and key-indexed
-		 * items that were used to generate the settings. This strips out the key-indexed
-		 * items for our logic.
-		 */
-		$numeric_only_settings = array_filter(
-			$settings,
-			function( $key ) {
-				return is_int( $key );
-			},
-			ARRAY_FILTER_USE_KEY
-		);
-
-		// Look for the beginning and end of the experimental_features_options section.
-		$indices = array_keys( array_column( $numeric_only_settings, 'id' ), 'experimental_features_options', true );
-		if ( 2 !== count( $indices ) ) {
-			return $settings;
-		}
-
-		// Add our own settings to the end of the featured section.
+	private function add_settings( array $settings ) {
 		$order_attribution_settings = [
 			[
 				'title'   => __( 'Order Attribution (Beta)', 'woocommerce-order-source-attribution' ),
@@ -107,10 +81,6 @@ class SettingsTab {
 			],
 		];
 
-		return array_merge(
-			array_slice( $numeric_only_settings, 0, $indices[1] ),
-			$order_attribution_settings,
-			array_slice( $numeric_only_settings, $indices[1] )
-		);
+		return array_merge( $settings, $order_attribution_settings );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Moves the settings under the normal featured section, rather than the experimental section

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?

### Changelog entry

>
