### PR TITLE
Update order information metaboxes

### DIFF
--- a/assets/css/order-source-attribution.css
+++ b/assets/css/order-source-attribution.css
@@ -1,0 +1,3 @@
+.order-source-attribution-metabox h4 {
+    margin-bottom: .1em;
+}

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -153,14 +153,7 @@ class AttributionFields {
 				if ( 'origin' !== $column_name ) {
 					return;
 				}
-
-				// Ensure we've got a valid order.
-				try {
-					$order = $this->get_hpos_order_object( $order_id );
-					$this->output_origin_column( $order );
-				} catch ( Exception $e ) {
-					return;
-				}
+				$this->display_origin_column( $order_id );
 			},
 			10,
 			2
@@ -348,6 +341,25 @@ class AttributionFields {
 	 */
 	private function display_customer_history( int $customer_id ) {
 		include dirname( WC_ORDER_ATTRIBUTE_SOURCE_FILE ) . '/templates/customer-history.php';
+	}
+
+	/**
+	 * Display the origin column in the orders table.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $order_id
+	 *
+	 * @return void
+	 */
+	private function display_origin_column( $order_id ): void {
+		// Ensure we've got a valid order.
+		try {
+			$order = $this->get_hpos_order_object( $order_id );
+			$this->output_origin_column( $order );
+		} catch ( Exception $e ) {
+			return;
+		}
 	}
 
 	/**

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -340,6 +340,11 @@ class AttributionFields {
 	 * @return void
 	 */
 	private function display_customer_history( int $customer_id ) {
+		// Calculate the data needed for the template.
+		$order_count   = wc_get_customer_order_count( $customer_id );
+		$total_spent   = wc_get_customer_total_spent( $customer_id );
+		$average_spent = $order_count ? $total_spent / $order_count : 0;
+
 		include dirname( WC_ORDER_ATTRIBUTE_SOURCE_FILE ) . '/templates/customer-history.php';
 	}
 

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -126,7 +126,7 @@ class AttributionFields {
 		add_action(
 			'add_meta_boxes',
 			function() {
-				$this->add_meta_box();
+				$this->add_meta_boxes();
 			}
 		);
 
@@ -314,11 +314,24 @@ class AttributionFields {
 	}
 
 	/**
+	 * Display the customer history template for the customer.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $customer_id
+	 *
+	 * @return void
+	 */
+	private function display_customer_history( int $customer_id ) {
+		include dirname( WC_ORDER_ATTRIBUTE_SOURCE_FILE ) . '/templates/customer-history.php';
+	}
+
+	/**
 	 * Add our own meta box to the order display screen.
 	 *
 	 * @return void
 	 */
-	private function add_meta_box() {
+	private function add_meta_boxes() {
 		add_meta_box(
 			'woocommerce-order-source-data',
 			__( 'Order information', 'woocommerce-order-source-attribution' ),
@@ -331,6 +344,21 @@ class AttributionFields {
 			},
 			$this->is_hpos_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order',
 			'side'
+		);
+
+		add_meta_box(
+			'woocommerce-customer-history',
+			__( 'Customer history', 'woocommerce-order-source-attribution' ),
+			function( $post ) {
+				try {
+					$order    = $this->get_hpos_order_object( $post );
+					$this->display_customer_history( $order->get_customer_id() );
+				} catch ( Exception $e ) {
+					$this->get_logger()->log_exception( $e, __METHOD__ );
+				}
+			},
+			$this->is_hpos_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order',
+			'side',
 		);
 	}
 

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -205,6 +205,8 @@ class AttributionFields {
 			wp_enqueue_style(
 				'woocommerce-order-source-attribution-admin-css',
 				plugins_url( 'assets/css/order-source-attribution.css', WC_ORDER_ATTRIBUTE_SOURCE_FILE ),
+				[],
+				WC_ORDER_ATTRIBUTE_SOURCE_VERSION
 			);
 		}
 	}
@@ -385,7 +387,7 @@ class AttributionFields {
 			__( 'Customer history', 'woocommerce-order-source-attribution' ),
 			function( $post ) {
 				try {
-					$order    = $this->get_hpos_order_object( $post );
+					$order = $this->get_hpos_order_object( $post );
 					$this->display_customer_history( $order->get_customer_id() );
 				} catch ( Exception $e ) {
 					$this->get_logger()->log_exception( $e, __METHOD__ );

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -86,7 +86,7 @@ class AttributionFields {
 		);
 
 		// Include our hidden fields on order notes and registration form.
-		$source_form_fields = function () {
+		$source_form_fields = function() {
 			$this->source_form_fields();
 		};
 
@@ -96,13 +96,13 @@ class AttributionFields {
 		// Update data based on submitted fields.
 		add_action(
 			'woocommerce_checkout_order_created',
-			function ( $order ) {
+			function( $order ) {
 				$this->set_order_source_data( $order );
 			}
 		);
 		add_action(
 			'user_register',
-			function ( $customer_id ) {
+			function( $customer_id ) {
 				try {
 					$customer = new WC_Customer( $customer_id );
 					$this->set_customer_source_data( $customer );
@@ -140,7 +140,7 @@ class AttributionFields {
 		// Add source data to the order table.
 		add_filter(
 			'manage_edit-shop_order_columns',
-			function ( $columns ) {
+			function( $columns ) {
 				$columns['origin'] = esc_html__( 'Origin', 'woocommerce-order-source-attribution' );
 
 				return $columns;
@@ -149,7 +149,7 @@ class AttributionFields {
 
 		add_action(
 			'manage_shop_order_posts_custom_column',
-			function ( $column_name, $order_id ) {
+			function( $column_name, $order_id ) {
 				if ( 'origin' !== $column_name ) {
 					return;
 				}
@@ -180,9 +180,7 @@ class AttributionFields {
 			true
 		);
 
-		/**
-		 * Pass parameters to Grow JS.
-		 */
+		// Pass parameters to Order Source Attribution JS.
 		$params = [
 			'lifetime'      => (int) apply_filters( 'wc_order_source_attribution_cookie_lifetime_months', 6 ),
 			'session'       => (int) apply_filters( 'wc_order_source_attribution_session_length_minutes', 30 ),
@@ -371,7 +369,7 @@ class AttributionFields {
 		add_meta_box(
 			'woocommerce-order-source-data',
 			__( 'Order information', 'woocommerce-order-source-attribution' ),
-			function ( $post ) {
+			function( $post ) {
 				try {
 					$this->display_order_source_data( $this->get_hpos_order_object( $post ) );
 				} catch ( Exception $e ) {
@@ -408,7 +406,7 @@ class AttributionFields {
 	private function filter_meta_data( array $meta ): array {
 		return array_filter(
 			$meta,
-			function ( WC_Meta_Data $meta ) {
+			function( WC_Meta_Data $meta ) {
 				return str_starts_with( $meta->key, '_wc_order_source_attribution_' );
 			}
 		);

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -330,7 +330,7 @@ class AttributionFields {
 				}
 			},
 			$this->is_hpos_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order',
-			'normal'
+			'side'
 		);
 	}
 

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -321,7 +321,7 @@ class AttributionFields {
 	private function add_meta_box() {
 		add_meta_box(
 			'woocommerce-order-source-data',
-			__( 'Order Source Data', 'woocommerce-order-source-attribution' ),
+			__( 'Order information', 'woocommerce-order-source-attribution' ),
 			function ( $post ) {
 				try {
 					$this->display_order_source_data( $this->get_hpos_order_object( $post ) );

--- a/src/Internal/AttributionFields.php
+++ b/src/Internal/AttributionFields.php
@@ -73,8 +73,15 @@ class AttributionFields {
 	public function register() {
 		add_action(
 			'wp_enqueue_scripts',
-			function () {
+			function() {
 				$this->enqueue_scripts_and_styles();
+			}
+		);
+
+		add_action(
+			'admin_enqueue_scripts',
+			function() {
+				$this->enqueue_admin_styles();
 			}
 		);
 
@@ -192,6 +199,23 @@ class AttributionFields {
 		];
 
 		wp_localize_script( 'woocommerce-order-attribute-source-js', 'wc_order_attribute_source_params', $params );
+	}
+
+	/**
+	 * Enqueue the stylesheet for admin pages.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	private function enqueue_admin_styles() {
+		$screen            = get_current_screen();
+		$order_page_suffix = $this->is_hpos_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		if ( $screen->id === $order_page_suffix ) {
+			wp_enqueue_style(
+				'woocommerce-order-source-attribution-admin-css',
+				plugins_url( 'assets/css/order-source-attribution.css', WC_ORDER_ATTRIBUTE_SOURCE_FILE ),
+			);
+		}
 	}
 
 	/**

--- a/templates/customer-history.php
+++ b/templates/customer-history.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 $orders = wc_get_orders(
 	[
 		'customer_id' => $customer_id,
-		'status' => array_map(
+		'status'      => array_map(
 			function( $value ) {
 				return "wc-{$value}";
 			},

--- a/templates/customer-history.php
+++ b/templates/customer-history.php
@@ -6,18 +6,54 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Variables used in this file.
  *
- *
+ * @var int $customer_id
  */
 
+/** @var WC_Order[] $orders */
+$orders = wc_get_orders(
+	[
+		'customer_id' => $customer_id,
+		'status' => array_map(
+			function( $value ) {
+				return "wc-{$value}";
+			},
+			wc_get_is_paid_statuses()
+		),
+	]
+);
+
+$order_count   = count( $orders );
+$total_spent   = array_reduce(
+	$orders,
+	function( $total, WC_Order $order ) {
+		return $total + $order->get_total();
+	},
+	0
+);
+$average_spent = $order_count ? $total_spent / $order_count : 0;
 ?>
 
 <div class="customer-history order-source-attribution-metabox">
-	<h4><?php esc_html_e( 'Total orders', 'woocommerce-order-source-attribution' ); ?></h4>
+	<h4>
+		<?php
+		esc_html_e( 'Total orders', 'woocommerce-order-source-attribution' );
+		echo wc_help_tip(
+			__( 'Total of completed orders by this customer, including the current one. Excludes cancelled or refunded orders.', 'woocommerce-order-source-attribution' )
+		); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		?>
+	</h4>
 
+	<span class="order-source-attribution-total-orders">
+		<?php echo esc_html( $order_count ); ?>
+	</span>
 
 	<h4><?php esc_html_e( 'Total spend', 'woocommerce-order-source-attribution' ); ?></h4>
-
+	<span class="order-source-attribution-total-spend">
+		<?php echo wc_price( $total_spent ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?>
+	</span>
 
 	<h4><?php esc_html_e( 'Average order value', 'woocommerce-order-source-attribution' ); ?></h4>
-
+	<span class="order-source-attribution-average-order-value">
+		<?php echo wc_price( $average_spent ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?>
+	</span>
 </div>

--- a/templates/customer-history.php
+++ b/templates/customer-history.php
@@ -1,0 +1,23 @@
+<?php
+declare( strict_types=1 );
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Variables used in this file.
+ *
+ *
+ */
+
+?>
+
+<div class="customer-history order-source-attribution-metabox">
+	<h4><?php esc_html_e( 'Total orders', 'woocommerce-order-source-attribution' ); ?></h4>
+
+
+	<h4><?php esc_html_e( 'Total spend', 'woocommerce-order-source-attribution' ); ?></h4>
+
+
+	<h4><?php esc_html_e( 'Average order value', 'woocommerce-order-source-attribution' ); ?></h4>
+
+</div>

--- a/templates/customer-history.php
+++ b/templates/customer-history.php
@@ -6,31 +6,10 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Variables used in this file.
  *
- * @var int $customer_id
+ * @var int   $order_count   The number of paid orders placed by the current customer.
+ * @var float $total_spent   The total money spent by the current customer.
+ * @var float $average_spent The average money spent by the current customer.
  */
-
-/** @var WC_Order[] $orders */
-$orders = wc_get_orders(
-	[
-		'customer_id' => $customer_id,
-		'status'      => array_map(
-			function( $value ) {
-				return "wc-{$value}";
-			},
-			wc_get_is_paid_statuses()
-		),
-	]
-);
-
-$order_count   = count( $orders );
-$total_spent   = array_reduce(
-	$orders,
-	function( $total, WC_Order $order ) {
-		return $total + $order->get_total();
-	},
-	0
-);
-$average_spent = $order_count ? $total_spent / $order_count : 0;
 ?>
 
 <div class="customer-history order-source-attribution-metabox">
@@ -38,7 +17,7 @@ $average_spent = $order_count ? $total_spent / $order_count : 0;
 		<?php
 		esc_html_e( 'Total orders', 'woocommerce-order-source-attribution' );
 		echo wc_help_tip(
-			__( 'Total of completed orders by this customer, including the current one. Excludes cancelled or refunded orders.', 'woocommerce-order-source-attribution' )
+			__( 'Total number of orders for this customer, including the current one.', 'woocommerce-order-source-attribution' )
 		); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 		?>
 	</h4>

--- a/templates/customer-history.php
+++ b/templates/customer-history.php
@@ -26,7 +26,14 @@ defined( 'ABSPATH' ) || exit;
 		<?php echo esc_html( $order_count ); ?>
 	</span>
 
-	<h4><?php esc_html_e( 'Total spend', 'woocommerce-order-source-attribution' ); ?></h4>
+	<h4>
+		<?php
+		esc_html_e( 'Total revenue', 'woocommerce-order-source-attribution' );
+		echo wc_help_tip(
+			__( "This is the Customer Lifetime Value, or the total amount you have earned from this customer's orders.", 'woocommerce-order-source-attribution' )
+		); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		?>
+	</h4>
 	<span class="order-source-attribution-total-spend">
 		<?php echo wc_price( $total_spent ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?>
 	</span>

--- a/templates/source-data-fields.php
+++ b/templates/source-data-fields.php
@@ -10,9 +10,7 @@ defined( 'ABSPATH' ) || exit;
  */
 ?>
 
-<div class="source_data form-field form-field-wide">
-	<h3><?php esc_html_e( 'Source Info', 'woocommerce-order-source-attribution' ); ?></h3>
-
+<div class="source_data form-field form-field-wide order-source-attribution-metabox">
 	<?php
 	foreach ( $meta as $item ) {
 		switch ( $item->key ) {

--- a/templates/source-data-fields.php
+++ b/templates/source-data-fields.php
@@ -1,38 +1,83 @@
 <?php
 declare( strict_types=1 );
 
+use Automattic\WooCommerce\OrderSourceAttribution\Internal\AttributionFields;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Variables used in this file.
  *
- * @var WC_Meta_Data[] $meta
+ * @var WC_Meta_Data[]    $meta
+ * @var AttributionFields $this
  */
+
+$keyed_meta = array_combine(
+	wp_list_pluck( $meta, 'key' ),
+	array_values( $meta )
+);
+
+$prefix = function( $name ) {
+	if ( $name === 'type' ) {
+		$name = 'source_type';
+	} elseif ( $name === 'url' ) {
+		$name = 'referrer';
+	}
+
+	return "_{$this->prefix_field( $name )}";
+};
 ?>
 
 <div class="source_data form-field form-field-wide order-source-attribution-metabox">
-	<?php
-	foreach ( $meta as $item ) {
-		switch ( $item->key ) {
-			case '_wc_order_source_attribution_referrer':
-				$label = __( 'Referrer', 'woocommerce-order-source-attribution' );
-				break;
 
-			case '_wc_order_source_attribution_source_type':
-				$label = __( 'Source type', 'woocommerce-order-source-attribution' );
-				break;
+	<?php if ( array_key_exists( $prefix( 'type' ), $keyed_meta ) ) : ?>
+		<h4>
+			<?php
+			esc_html_e( 'Origin', 'woocommerce-order-source-attribution' );
+			echo wc_help_tip(
+				__( 'The origin of the order', 'woocommerce-order-source-attribution' )
+			); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			?>
+		</h4>
+		<span class="order-source-attribution-origin">
+			<?php echo esc_html( $keyed_meta[ $prefix( 'type' ) ]->value ); ?>
+		</span>
+	<?php endif; ?>
 
-			default:
-				$label = str_replace( [ '_wc_order_source_attribution_', '_' ], [ '', ' ' ], $item->key );
-				$label = ucwords( $label );
-				break;
-		}
-		?>
-		<p class="form-field form-field-wide">
-			<label><?php echo esc_html( $label ); ?>:</label>
-			<?php echo esc_html( $item->value ); ?>
-		</p>
-		<?php
-	}
-	?>
+	<?php if ( array_key_exists( $prefix( 'source_type' ), $keyed_meta ) ) : ?>
+		<h4><?php esc_html_e( 'Source type', 'woocommerce-order-source-attribution' ); ?></h4>
+		<span class="order-source-attribution-source_type">
+			<?php echo esc_html( $keyed_meta[ $prefix( 'source_type' ) ]->value ); ?>
+		</span>
+	<?php endif; ?>
+
+	<?php if ( array_key_exists( $prefix( 'utm_campaign' ), $keyed_meta ) ) : ?>
+		<h4><?php esc_html_e( 'UTM campaign', 'woocommerce-order-source-attribution' ); ?></h4>
+		<span class="order-source-attribution-utm-campaign">
+			<?php echo esc_html( $keyed_meta[ $prefix( 'utm_campaign' ) ]->value ); ?>
+		</span>
+	<?php endif; ?>
+
+	<?php if ( array_key_exists( $prefix( 'utm_source' ), $keyed_meta ) ) : ?>
+		<h4><?php esc_html_e( 'UTM source', 'woocommerce-order-source-attribution' ); ?></h4>
+		<span class="order-source-attribution-utm-source">
+			<?php echo esc_html( $keyed_meta[ $prefix( 'utm_source' ) ]->value ); ?>
+		</span>
+	<?php endif; ?>
+
+	<?php if ( array_key_exists( $prefix( 'utm_medium' ), $keyed_meta ) ) : ?>
+		<h4><?php esc_html_e( 'UTM medium', 'woocommerce-order-source-attribution' ); ?></h4>
+		<span class="order-source-attribution-utm-medium">
+			<?php echo esc_html( $keyed_meta[ $prefix( 'utm_medium' ) ]->value ); ?>
+		</span>
+	<?php endif; ?>
+
+	<!-- todo: Device type -->
+
+	<?php if ( array_key_exists( $prefix( 'session_pages' ), $keyed_meta ) ) : ?>
+		<h4><?php esc_html_e( 'Session page views', 'woocommerce-order-source-attribution' ); ?></h4>
+		<span class="order-source-attribution-utm-session-pages">
+			<?php echo esc_html( $keyed_meta[ $prefix( 'session_pages' ) ]->value ); ?>
+		</span>
+	<?php endif; ?>
 </div>

--- a/templates/source-data-fields.php
+++ b/templates/source-data-fields.php
@@ -18,9 +18,9 @@ $keyed_meta = array_combine(
 );
 
 $prefix = function( $name ) {
-	if ( $name === 'type' ) {
+	if ( 'type' === $name ) {
 		$name = 'source_type';
-	} elseif ( $name === 'url' ) {
+	} elseif ( 'url' === $name ) {
 		$name = 'referrer';
 	}
 

--- a/templates/source-data-fields.php
+++ b/templates/source-data-fields.php
@@ -31,14 +31,7 @@ $prefix = function( $name ) {
 <div class="source_data form-field form-field-wide order-source-attribution-metabox">
 
 	<?php if ( array_key_exists( $prefix( 'type' ), $keyed_meta ) ) : ?>
-		<h4>
-			<?php
-			esc_html_e( 'Origin', 'woocommerce-order-source-attribution' );
-			echo wc_help_tip(
-				__( 'The origin of the order', 'woocommerce-order-source-attribution' )
-			); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-			?>
-		</h4>
+		<h4><?php esc_html_e( 'Origin', 'woocommerce-order-source-attribution' ); ?></h4>
 		<span class="order-source-attribution-origin">
 			<?php echo esc_html( $keyed_meta[ $prefix( 'type' ) ]->value ); ?>
 		</span>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Update the panel label
- Move the panel to the side
- Update classes and remove extra `<h3>` tag
- Initial file for the customer history data
- Add the Customer history meta box
- Add the stylesheet for our metaboxes
- Create separate method for the origin column
- Tweak some code styles
- Update the order field template based on designs

Closes #61, #62.

***Note:*** There are a few small tweaks needed, but those are awaiting some questions being answered. I wanted to get the bulk of this up for review first.

### Checks:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards?

### Detailed test instructions
*Refer to the documents (P2, Figma) mentioned in #57*
1. Create an Order
2. Verify that the Order information box has been updated with the design changes
3. Verify that the Customer history box has been added with the correct data

### Changelog entry

>
